### PR TITLE
Added Function to set amx parameter which should be preferred instead…

### DIFF
--- a/goecharger/goecharger.py
+++ b/goecharger/goecharger.py
@@ -263,6 +263,13 @@ class GoeCharger:
             current = 32
         return self.__setParameter('amp', str(current))
 
+    def setPVMaxCurrent(self, current):
+        if current < 6:
+            current = 6
+        if current > 32:
+            current = 32
+        return self.__setParameter('amx', str(current))
+
     def setChargeLimit(self, chargeLimit):
         limit = int(chargeLimit * 10) if chargeLimit >= 0 else 0
         return self.__setParameter('dwo', str(limit))


### PR DESCRIPTION
… of amp parameter

See: https://github.com/goecharger/go-eCharger-API-v1/blob/master/go-eCharger%20API%20v1%20DE.md

amx will not be persisted into the flash and is the preferred method for PV control